### PR TITLE
Release plugin update: 1.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ Unlimited.
 
 ### Changelog
 
+**1.0.3**
+
+- Fixes minor PHP warnings and notices.
+
 **1.0.2**
 
 - Fixes issue where the plugin was adding an additional dropdown to the Page Attributes metabox (props to [@honoluluman](https://profiles.wordpress.org/honoluluman/) for reporting it)
@@ -86,6 +90,10 @@ Unlimited.
 - Initial Release
 
 ### Upgrade Notice
+
+**1.0.3**
+
+- Fixes minor PHP warnings and notices.
 
 **1.0.2**
 

--- a/bp-custom-menu.php
+++ b/bp-custom-menu.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://nahid.dev/project/bp-custom-menu
  * Description: Create custom BuddyPress profile menu pages, gracefully.
  * Author: Nahid Ferdous Mohit
- * Version: 1.0.2
+ * Version: 1.0.3
  * Author URI: https://nahid.dev
  * Text Domain: bp-custom-menu
  *

--- a/includes/metaboxes/extend-menu-page-options.php
+++ b/includes/metaboxes/extend-menu-page-options.php
@@ -60,18 +60,18 @@ add_action( 'page_attributes_misc_attributes', 'menu_page_options_extend_attribu
 function save_menu_page_options( $post_id ) {
 	if( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) return;
 
-	if( !isset( $_POST['meta_box_nonce'] ) || !wp_verify_nonce( $_POST['meta_box_nonce'], 'bp_custom_menu_meta_box_nonce' ) ) return;
+	if( ! isset( $_POST[ 'meta_box_nonce' ] ) || !wp_verify_nonce( $_POST[ 'meta_box_nonce' ], 'bp_custom_menu_meta_box_nonce' ) ) return;
 
-	if( !current_user_can( 'edit_post' ) ) return;
+	if( ! current_user_can( 'edit_post', $post_id ) ) return;
 
 	/* Default Submenu */
 
-	if( isset( $_POST['default_submenu'] ) ) {
+	if( isset( $_POST[ 'default_submenu' ] ) ) {
 
-		$value = sanitize_text_field( $_POST['default_submenu'] );
+		$value = sanitize_text_field( $_POST[ 'default_submenu' ] );
 
 		$args = array(
-		    'post_parent' => $post->ID,
+		    'post_parent' => $post_id,
 		    'post_type'   => 'bp_custom_menu_page',
 		);
 		$submenus = get_children( $args );

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: nfmohit
 Donate link: https://www.patreon.com/nfmohit
 Tags: buddypress, profile, custom, menu, wordpress
 Requires at least: 4.0
-Tested up to: 5.4
-Stable tag: 1.0.2
+Tested up to: 5.5
+Stable tag: 1.0.3
 Requires PHP: 5.6
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -94,6 +94,9 @@ Unlimited.
 
 == Changelog ==
 
+= 1.0.3 =
+* Fixes minor PHP warnings and notices.
+
 = 1.0.2 =
 * Fixes issue where the plugin was adding an additional dropdown to the Page Attributes metabox (props to [@honoluluman](https://profiles.wordpress.org/honoluluman/) for reporting it)
 
@@ -104,6 +107,9 @@ Unlimited.
 * Initial Release
 
 == Upgrade Notice ==
+
+= 1.0.3 =
+* Fixes minor PHP warnings and notices.
 
 = 1.0.2 =
 * Bug Fix: An additional dropdown was being added to the Page Attributes metabox


### PR DESCRIPTION
This PR adds in the required changes for the plugin's 1.0.3 update. This update includes:

1. Fixes to minor PHP warnings and notices.
2. Compatibility with the latest WordPress version.